### PR TITLE
Bump version to 0.23.0 (#1) (now from branch 0.23)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
-lazy val finchVersion = "0.21.0"
-lazy val json4sVersion = "3.5.4"
+lazy val finchVersion = "0.23.0"
+lazy val json4sVersion = "3.6.0"
 
 lazy val buildSettings = Seq(
   organization := "com.github.finagle",


### PR DESCRIPTION
This PR replaces https://github.com/finch/finch-json4s/pull/2

By mistake, the previous fix was done on master, instead of being done on a separate branch.
 